### PR TITLE
Fix for NCZ/NSZ cert installs to prevent crash on instal

### DIFF
--- a/source/install/nsp.cpp
+++ b/source/install/nsp.cpp
@@ -67,21 +67,32 @@ namespace tin::install::nsp
     }
 
     std::vector<const PFS0FileEntry*> NSP::GetFileEntriesByExtension(std::string extension)
-    {
-        std::vector<const PFS0FileEntry*> entryList;
+	{
+		std::vector<const PFS0FileEntry*> entryList;
 
-        for (unsigned int i = 0; i < this->GetBaseHeader()->numFiles; i++)
-        {
-            const PFS0FileEntry* fileEntry = this->GetFileEntry(i);
-            std::string name(this->GetFileEntryName(fileEntry));
-            auto foundExtension = name.substr(name.find(".") + 1); 
+		for (unsigned int i = 0; i < this->GetBaseHeader()->numFiles; i++)
+		{
+			const PFS0FileEntry* fileEntry = this->GetFileEntry(i);
+			std::string name(this->GetFileEntryName(fileEntry));
+			auto foundExtension = name.substr(name.find(".") + 1);
+				
+			// fix cert filename extension becoming corrupted when xcz/nsz is installing certs.
+			std::string cert ("cert");
+			std::size_t found = name.find(cert);
+			if (found!=std::string::npos){
+				int pos = 0;
+				std::string mystr = name;
+				pos = mystr.find_last_of('.');
+				mystr = mystr.substr(5, pos);
+				foundExtension = mystr.substr(mystr.find(".") + 1);
+			}
 
-            if (foundExtension == extension)
-                entryList.push_back(fileEntry);
-        }
+			if (foundExtension == extension)
+				entryList.push_back(fileEntry);
+		}
 
-        return entryList;
-    }
+		return entryList;
+	}
 
     const PFS0FileEntry* NSP::GetFileEntryByName(std::string name)
     {

--- a/source/install/xci.cpp
+++ b/source/install/xci.cpp
@@ -150,22 +150,33 @@ namespace tin::install::xci
         return fileEntry;
     }
 
-    std::vector<const HFS0FileEntry*> XCI::GetFileEntriesByExtension(std::string extension)
-    {
-        std::vector<const HFS0FileEntry*> entryList;
+    std::vector<const PFS0FileEntry*> NSP::GetFileEntriesByExtension(std::string extension)
+	{
+		std::vector<const PFS0FileEntry*> entryList;
 
-        for (unsigned int i = 0; i < this->GetSecureHeader()->numFiles; i++)
-        {
-            const HFS0FileEntry* fileEntry = this->GetFileEntry(i);
-            std::string name(this->GetFileEntryName(fileEntry));
-            auto foundExtension = name.substr(name.find(".") + 1); 
+		for (unsigned int i = 0; i < this->GetBaseHeader()->numFiles; i++)
+		{
+			const PFS0FileEntry* fileEntry = this->GetFileEntry(i);
+			std::string name(this->GetFileEntryName(fileEntry));
+			auto foundExtension = name.substr(name.find(".") + 1);
+				
+			// fix cert filename extension becoming corrupted when xcz/nsz is installing certs.
+			std::string cert ("cert");
+			std::size_t found = name.find(cert);
+			if (found!=std::string::npos){
+				int pos = 0;
+				std::string mystr = name;
+				pos = mystr.find_last_of('.');
+				mystr = mystr.substr(5, pos);
+				foundExtension = mystr.substr(mystr.find(".") + 1);
+			}
 
-            if (foundExtension == extension)
-                entryList.push_back(fileEntry);
-        }
+			if (foundExtension == extension)
+				entryList.push_back(fileEntry);
+		}
 
-        return entryList;
-    }
+		return entryList;
+	}
 
     const char* XCI::GetFileEntryName(const HFS0FileEntry* fileEntry)
     {


### PR DESCRIPTION
Currently a random crash happens when installing from NCZ/NSZ files. This is down to the cert file entry in the file entry table having a corrupt file extension name. When the cert tries to install, the filename extension is wrong which causes a crash.

This bug is random, but can be fixed by modding nsp.cpp and xci.cpp to the following,

#193 is an issue on this project. It tells us how to fix the project, but it doesn't make a PR. So I made this PR implementing [mrdude2478](https://github.com/mrdude2478) fix. 