### PR TITLE
add ci-cd-cd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Build & Deploy
+on: [push, pull_request]
+jobs:
+  build:
+    name: "Build"
+    runs-on: ubuntu-latest
+    container: devkitpro/devkita64:latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - name: Silence git safe directory warnings
+      run: git config --system --add safe.directory '*'
+    - name: Assembly nro
+      run: make -j$(nproc) -l$(nproc)
+    - uses: actions/upload-artifact@v6
+      with:
+        path: Awoo-Installer.nro
+        if-no-files-found: error
+  release:
+    name: "Publish release"
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: ${{ github.event_name == 'push' }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Remove old release and upload new release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: bash ci-scripts/make_release.sh "${{ github.repository }}" "${{ github.ref_name }}"

--- a/ci-scripts/make_release.sh
+++ b/ci-scripts/make_release.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+if ! command -v gh > /dev/null; then
+	echo "Install GitHub CLI tool"
+	exit 1
+fi
+
+RELEASE_NAME=$(echo -n $1 | sed -e 's/^.*\///g')
+BRANCH_NAME=$2
+DEFAULT_BRANCH_NAME=master
+
+if [ -z "$RELEASE_NAME" ] || [ -z "$BRANCH_NAME" ]; then
+	echo "Invalid arguments"
+	exit 1
+fi
+
+if [ "$BRANCH_NAME" == "$DEFAULT_BRANCH_NAME" ]; then
+	RELEASE_TAG="continuous"
+else
+	RELEASE_TAG="continuous-$BRANCH_NAME"
+fi
+
+gh release delete "$RELEASE_TAG" \
+	--yes \
+	--cleanup-tag \
+	--repo "$GITHUB_REPOSITORY" || true
+
+gh run download "$GITHUB_RUN_ID" \
+	--dir artifacts/ \
+	--repo "$GITHUB_REPOSITORY"
+
+pushd artifacts/ || exit 1
+echo "Artifacts:"
+ls
+for i in $(find -mindepth 1 -maxdepth 1 -type d); do
+	mv "$i"/* .
+	rmdir "$i"
+done
+echo "Repackaged artifacts:"
+ls -R
+popd || exit 1
+
+git log -1 --pretty=format:'%h%nBy %aN at %ai' > release-notes
+
+sleep 10s
+gh release create "$RELEASE_TAG" artifacts/* \
+	--title "$RELEASE_NAME Continuous $BRANCH_NAME build" \
+	--notes-file release-notes \
+	--target "$GITHUB_SHA" \
+	--repo "$GITHUB_REPOSITORY" \
+	--prerelease


### PR DESCRIPTION
Let's create rolling (pre-)releases on push!

Example of how it works:
https://github.com/developersu/Awoo-Installer/releases

Requires github-token to work with 'Contents' permission. 

Example: 
<img width="910" height="1024" alt="yeah" src="https://github.com/user-attachments/assets/a56cbf16-65c9-4631-89d8-4a1b73751f19" />